### PR TITLE
schema: Add docker overrides for entrypoint and user

### DIFF
--- a/examples/projects/entrypoint.yml
+++ b/examples/projects/entrypoint.yml
@@ -1,0 +1,16 @@
+timeout: 5
+triggers:
+  - name: git
+    type: git_poller
+    runs:
+      - name: docker-run-option
+        container: alpine
+        host-tag: amd643
+        # The docker run command will include: --entrypoint=""
+        container-entrypoint: ""
+        script: compile
+
+scripts:
+  compile: |
+    #!/bin/sh -ex
+    echo "hello with no entrypoint"

--- a/examples/projects/run-as.yml
+++ b/examples/projects/run-as.yml
@@ -1,0 +1,16 @@
+timeout: 5
+triggers:
+  - name: git
+    type: git_poller
+    runs:
+      - name: docker-run-option
+        container: alpine
+        host-tag: amd643
+        # The docker run command will include "--user nobody"
+        container-user: nobody
+        script: compile
+
+scripts:
+  compile: |
+    #!/bin/sh -ex
+    echo "hello as nobody"

--- a/jobserv/project-schema.yml
+++ b/jobserv/project-schema.yml
@@ -95,6 +95,12 @@ mapping:
                   privileged:
                     type: bool
                     required: false
+                  container-user:
+                    type: str
+                    required: false
+                  container-entrypoint:
+                    type: str
+                    required: false
                   host-tag:
                     type: str
                     required: False

--- a/jobserv/project.py
+++ b/jobserv/project.py
@@ -111,6 +111,8 @@ class ProjectDefinition(object):
             'container': run['container'],
             'container-auth': run.get('container-auth'),
             'privileged': run.get('privileged', False),
+            'container-user': run.get('container-user'),
+            'container-entrypoint': run.get('container-entrypoint'),
             'env': {},
             'secrets': secrets,
             'test-grepping': run.get('test-grepping'),

--- a/runner/jobserv_runner/handlers/simple.py
+++ b/runner/jobserv_runner/handlers/simple.py
@@ -200,6 +200,14 @@ class SimpleHandler(object):
             if self.rundef.get('privileged'):
                 log.info('Running with "--privileged"')
                 cmd.append('--privileged')
+            if self.rundef.get('container-user'):
+                user = self.rundef.get('container-user')
+                log.info('Overriding container user to be: %s', user)
+                cmd.extend(['--user', user])
+            if self.rundef.get('container-entrypoint'):
+                ep = self.rundef.get('container-entrypoint')
+                log.info('Overriding container entrypointpoint to be: %s', ep)
+                cmd.extend(['--entrypoint', ep])
             cmd.extend(['-v%s:%s' % (host, cont) for host, cont in mounts])
             cmd.extend(
                 [self.rundef['container'], self._container_command])


### PR DESCRIPTION
We have two issues in CI right now that both require overriding
default docker-run behavior.

1) A container with a non-root user may not be able to save artifacts
If the worker is run as root, then /archive is owned by root and the
the container user won't be able to write to it.

2) A container may have an entrypoint we don't want to run
A container like:

 https://github.com/zephyrproject-rtos/docker-image

Includes an entrypoint we don't really want to run in our CI.

Signed-off-by: Andy Doan <andy@foundries.io>