### PR TITLE
Add ability to cancel a Run

### DIFF
--- a/jobserv/api/health.py
+++ b/jobserv/api/health.py
@@ -29,10 +29,12 @@ def run_health():
     health['RUNNING'] = {}
     health['QUEUED'] = []
 
-    active = (BuildStatus.QUEUED, BuildStatus.RUNNING, BuildStatus.UPLOADING)
+    active = (BuildStatus.QUEUED, BuildStatus.RUNNING, BuildStatus.UPLOADING,
+              BuildStatus.CANCELLING)
     runs = Run.query.filter(Run.status.in_(active)).order_by(
         Run.queue_priority.asc(), Run.build_id.asc(), Run.id.asc())
     for run in runs:
+        print("ANDY RUN", run)
         url = url_for('api_run.run_get', proj=run.build.project.name,
                       build_id=run.build.build_id,
                       run=run.name, _external=True)
@@ -49,5 +51,5 @@ def run_health():
         else:
             worker = run.worker_name or '?'
             health['RUNNING'].setdefault(worker, []).append(item)
-
+    print("ANDY", health)
     return jsendify({'health': health})

--- a/jobserv/models.py
+++ b/jobserv/models.py
@@ -46,10 +46,11 @@ def get_cumulative_status(items):
        status of its child TestResults and Runs.'''
     status = BuildStatus.QUEUED  # Default guess to QUEUED
     states = set([x.status for x in items])
-    if BuildStatus.RUNNING in states or BuildStatus.UPLOADING in states:
+    if BuildStatus.RUNNING in states or BuildStatus.UPLOADING in states \
+            or BuildStatus.CANCELLING in states:
         # Something is still running
         status = BuildStatus.RUNNING
-        if BuildStatus.FAILED in states:
+        if BuildStatus.FAILED in states or BuildStatus.CANCELLING in states:
             status = BuildStatus.RUNNING_WITH_FAILURES
     if BuildStatus.QUEUED in states and BuildStatus.FAILED in states:
         status = BuildStatus.RUNNING_WITH_FAILURES
@@ -183,6 +184,8 @@ class BuildStatus(enum.Enum):
     PROMOTED = 7  # ie - the build got "released"
 
     SKIPPED = 8  # only valid for Test and TestResult
+    # only valid for Run. Its been *requested*. The worker will then *fail*
+    CANCELLING = 9
 
 
 class StatusComparator(Comparator):

--- a/jobserv/models.py
+++ b/jobserv/models.py
@@ -41,7 +41,7 @@ orig_create = mysqldb.MySQLDialect_mysqldb.create_connect_args
 mysqldb.MySQLDialect_mysqldb.create_connect_args = hack_create_connect_args
 
 
-def get_cumulative_status(obj, items):
+def get_cumulative_status(items):
     '''A helper used by Test and Build to calculate the status based on the
        status of its child TestResults and Runs.'''
     status = BuildStatus.QUEUED  # Default guess to QUEUED
@@ -293,7 +293,7 @@ class Build(db.Model, StatusMixin):
         return data
 
     def refresh_status(self):
-        status = get_cumulative_status(self, self.runs)
+        status = get_cumulative_status(self.runs)
         if self.status != status:
             self.status = status
             db.session.add(BuildEvents(self, status))
@@ -547,7 +547,7 @@ class Test(db.Model, StatusMixin):
             status = BuildStatus[status]
         if self.status != status:
             self.status = status
-            return get_cumulative_status(self.run, self.run.tests)
+            return get_cumulative_status(self.run.tests)
 
     @property
     def complete(self):

--- a/runner/jobserv_runner/handlers/simple.py
+++ b/runner/jobserv_runner/handlers/simple.py
@@ -525,7 +525,8 @@ class SimpleHandler(object):
         except HandlerError as e:
             jobserv.update_status('FAILED', str(e))
         except RunCancelledError as e:
-            jobserv.update_status('FAILED', 'Run cancelled from server')
+            jobserv.update_status('FAILED',
+                                  'Run cancelled from server\n' + failed_msg)
         except Exception as e:
             if getattr(e, 'handler_logged', False):
                 # we've already logged the stack trace, just fail the run

--- a/runner/jobserv_runner/handlers/simple.py
+++ b/runner/jobserv_runner/handlers/simple.py
@@ -17,7 +17,7 @@ import urllib.parse
 import uuid
 
 from jobserv_runner.cmd import stream_cmd
-from jobserv_runner.jobserv import JobServApi
+from jobserv_runner.jobserv import JobServApi, RunCancelledError
 from jobserv_runner.logging import ContextLogger
 
 passed_msg = '''Runner has completed
@@ -524,6 +524,8 @@ class SimpleHandler(object):
             raise
         except HandlerError as e:
             jobserv.update_status('FAILED', str(e))
+        except RunCancelledError as e:
+            jobserv.update_status('FAILED', 'Run cancelled from server')
         except Exception as e:
             if getattr(e, 'handler_logged', False):
                 # we've already logged the stack trace, just fail the run

--- a/runner/jobserv_runner/jobserv.py
+++ b/runner/jobserv_runner/jobserv.py
@@ -26,6 +26,10 @@ class PostError(Exception):
     pass
 
 
+class RunCancelledError(Exception):
+    pass
+
+
 def urllib_error_str(e):
     if hasattr(e, 'code'):
         error = 'HTTP_%d' % e.code
@@ -43,6 +47,8 @@ def _post(url, data, headers, raise_error=False):
         url, data=data, headers=headers, method='POST')
     try:
         resp = urllib.request.urlopen(req)
+        if resp.headers.get('X-JOBSERV-CANCEL'):
+            raise RunCancelledError()
         return resp
     except urllib.error.URLError as e:
         error = urllib_error_str(e)

--- a/runner/jobserv_runner/logging.py
+++ b/runner/jobserv_runner/logging.py
@@ -7,6 +7,8 @@ import traceback
 
 from io import StringIO
 
+from jobserv_runner.jobserv import RunCancelledError
+
 
 class ContextLogger():
     """A simplistic logger that can be used to stream things to the local
@@ -39,7 +41,7 @@ class ContextLogger():
         return self
 
     def __exit__(self, type, value, tb):
-        if tb:
+        if type != RunCancelledError and tb:
             msg = ''.join(traceback.format_exception(type, value, tb))
             self.error(msg.replace('\n', '\n   |'))
 

--- a/tests/runner/test_logging.py
+++ b/tests/runner/test_logging.py
@@ -5,6 +5,7 @@ import datetime
 
 from unittest import TestCase
 
+from jobserv_runner.jobserv import RunCancelledError
 from jobserv_runner.logging import ContextLogger
 
 
@@ -34,3 +35,20 @@ class LoggerTest(TestCase):
 
     def test_error(self):
         self._test_log('error')
+
+    def test_exec(self):
+        log = TestLogger('test_exec')
+        log.now = datetime.datetime.utcnow()
+        with self.assertRaises(RuntimeError):
+            with log:
+                raise RuntimeError()
+        self.assertIn('|    raise RuntimeError', log.io.getvalue())
+
+    def test_exec_cancelled(self):
+        log = TestLogger('test_exec_cancelled')
+        log.now = datetime.datetime.utcnow()
+        with self.assertRaises(RunCancelledError):
+            with log:
+                raise RunCancelledError()
+        expected = '== %s: test_exec_cancelled\n' % log.now
+        self.assertEqual(expected, log.io.getvalue())

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -35,6 +35,10 @@ class HealthApiTest(JobServTest):
         r.worker = w2
         r.status = BuildStatus.RUNNING
         db.session.add(r)
+        r = Run(b, 'run3rworker2')
+        r.worker = w2
+        r.status = BuildStatus.CANCELLING
+        db.session.add(r)
         db.session.commit()
 
         r = self.client.get('/health/runs/')
@@ -46,6 +50,6 @@ class HealthApiTest(JobServTest):
         self.assertEqual(1, d['health']['statuses']['UPLOADING'])
 
         self.assertEqual(1, len(d['health']['RUNNING']['worker1']))
-        self.assertEqual(2, len(d['health']['RUNNING']['worker2']))
+        self.assertEqual(3, len(d['health']['RUNNING']['worker2']))
 
         self.assertEqual(2, len(d['health']['QUEUED']))

--- a/tests/test_api_run.py
+++ b/tests/test_api_run.py
@@ -152,6 +152,20 @@ class RunAPITest(JobServTest):
         self.assertEqual('text/plain', resp.mimetype)
 
     @patch('jobserv.storage.gce_storage.storage')
+    def test_run_cancel(self, storage):
+        r = Run(self.build, 'run0')
+        db.session.add(r)
+        db.session.commit()
+
+        headers = [
+            ('Authorization', 'Token %s' % r.api_key),
+            ('X-RUN-STATUS', 'CANCEL'),
+        ]
+        self._post(self.urlbase + 'run0/', 'message', headers, 200)
+        db.session.refresh(r)
+        self.assertEqual(BuildStatus.CANCELLING, r.status)
+
+    @patch('jobserv.storage.gce_storage.storage')
     def test_run_metadata(self, storage):
         r = Run(self.build, 'run0')
         db.session.add(r)

--- a/tests/test_api_run.py
+++ b/tests/test_api_run.py
@@ -112,6 +112,22 @@ class RunAPITest(JobServTest):
         permissions._sign(url, headers, 'POST')
         self._post(url, 'message', headers, 200)
 
+    @patch('jobserv.storage.gce_storage.storage')
+    def test_run_cancel(self, storage):
+        r = Run(self.build, 'run0')
+        db.session.add(r)
+        db.session.commit()
+
+        headers = {}
+        url = 'http://localhost' + self.urlbase + 'run0/cancel'
+
+        self._post(url, 'message', headers, 401)
+
+        permissions._sign(url, headers, 'POST')
+        self._post(url, '', headers, 202)
+        db.session.refresh(r)
+        self.assertEqual(BuildStatus.CANCELLING, r.status)
+
     def test_run_stream_not_authenticated(self):
         r = Run(self.build, 'run0')
         db.session.add(r)
@@ -150,20 +166,6 @@ class RunAPITest(JobServTest):
         resp = self.client.get(self.urlbase + 'run0/console.log')
         self.assertEqual(200, resp.status_code)
         self.assertEqual('text/plain', resp.mimetype)
-
-    @patch('jobserv.storage.gce_storage.storage')
-    def test_run_cancel(self, storage):
-        r = Run(self.build, 'run0')
-        db.session.add(r)
-        db.session.commit()
-
-        headers = [
-            ('Authorization', 'Token %s' % r.api_key),
-            ('X-RUN-STATUS', 'CANCEL'),
-        ]
-        self._post(self.urlbase + 'run0/', 'message', headers, 200)
-        db.session.refresh(r)
-        self.assertEqual(BuildStatus.CANCELLING, r.status)
 
     @patch('jobserv.storage.gce_storage.storage')
     def test_run_metadata(self, storage):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -131,6 +131,20 @@ class BuildTest(JobServTest):
         )
         self.assertEqual(BuildStatus.PASSED, get_cumulative_status(items))
 
+        items = (
+            unittest.mock.Mock(status=BuildStatus.QUEUED),
+            unittest.mock.Mock(status=BuildStatus.CANCELLING),
+        )
+        self.assertEqual(
+            BuildStatus.RUNNING_WITH_FAILURES, get_cumulative_status(items))
+
+        items = (
+            unittest.mock.Mock(status=BuildStatus.PASSED),
+            unittest.mock.Mock(status=BuildStatus.CANCELLING),
+        )
+        self.assertEqual(
+            BuildStatus.RUNNING_WITH_FAILURES, get_cumulative_status(items))
+
 
 class RunTest(JobServTest):
     def setUp(self):


### PR DESCRIPTION
This change allows you to do something like:
~~~
 curl -X POST -H "X-JOBSERV-CANCEL: 1" https://api.foundries.io/projects/lmp/builds/X/runs/foo/
~~~
The Run will then be mark as CANCELLING in the database and API. The JobServ worker will eventually see this as it reports its run status to the server and forcefully exit.

Its not totally foolproof:
 * A Run stuck uploading a lot of artifacts won't get cancelled until its done uploading because it won't see this state change.
 * A Run that just works for a long time and produces no stderr/stdout data will hang because its not reporting anything to the server.

However, those are edge cases which *could* be covered but rarely if ever happen in practice.