### PR TITLE
Fix synchronous project build logic with tags

### DIFF
--- a/jobserv/project.py
+++ b/jobserv/project.py
@@ -120,16 +120,7 @@ class ProjectDefinition(object):
             'host-tag': run.get('host-tag'),
         }
 
-        # We allow host-tag pattern matching using fnmatch type * and ?
-        # ie * matches everything and ? matches a single character.
-        # In sql we need * and ? to maps to % and _ respectively
-        # Since _ is a special character we need to escape that. And
-        # we also make all host-tags lowercase so we can be case-insensitve
-        #
-        # Soo... a pattern like: H?st_b* would become: h_st\_b%
-        # and would match stuff like host_b and hast_FOOO
-        rundef['host-tag'] = run['host-tag'].lower(
-        ).replace('*', '%').replace('_', '\_').replace('?', '_')
+        rundef['host-tag'] = run['host-tag'].lower()
         if 'script' in run:
             rundef['script'] = self.scripts[run['script']]
         else:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -237,8 +237,8 @@ class ProjectSchemaTest(JobServTest):
             run = trigger['runs'][0]
             rundef = proj.get_run_definition(dbrun, run, trigger, {}, {})
             data = json.loads(rundef)
-            self.assertEqual('aarch6%', data['host-tag'])
-            self.assertEqual('aarch6%', dbrun.host_tag)
+            self.assertEqual('aarch6*', data['host-tag'])
+            self.assertEqual('aarch6*', dbrun.host_tag)
 
     def test_host_tag_rundef_loopon(self):
         with open(os.path.join(self.examples, 'host-tag.yml')) as f:


### PR DESCRIPTION
We hit the following issue in production with a synchronous project:

* long running build with one run for the amd64 host-tag is RUNNING
* a new build for this project is QUEUED with:
  run-1 - host-tag=amd64
  run-2 - host-tag=armhf
  run-3 - host-tag=aarch64

The query we have to find candidates is filtering on host-tag, so we
accidentally allowed run-2 and run-3 to get executed before the
first long running build was done.

The code did handle the "run-1" properly since their host tags matched.

The fix here is to handle the host-tag filtering *after* we find our
candidates. Since we no longer filter inside SQL, we can go back to
letting our host-tags be in python's fnmatch style format.

I also renamed the runs in the test to make them a bit
easier to understand.

Signed-off-by: Andy Doan <andy@foundries.io>