### PR TITLE
runner: Improve command polling logic

### DIFF
--- a/runner/jobserv_runner/cmd.py
+++ b/runner/jobserv_runner/cmd.py
@@ -21,10 +21,7 @@ def _cmd_output(cmd, cwd=None, env=None):
         poller.register(fd, select.POLLIN)
 
     while len(fds) > 0:
-        events = poller.poll(0.1)
-        if not events and p.poll() is not None:
-            break
-        for fd, event in events:
+        for fd, event in poller.poll(1000):
             if event & select.POLLIN:
                 yield os.read(fd, 1024)
             elif event & select.POLLHUP:


### PR DESCRIPTION
pyton3.4 and greater return an empty list, so we can be simplify how we
call the poll api.

Additionally the timeout value was wrong. It was assuming seconds and
the expected value is milliseconds. This leads to some aggressive
polling and we really don't have anything useful to do while we wait on
output.

Signed-off-by: Andy Doan <andy@foundries.io>