### PR TITLE
runner: Copy docker host config into container

### DIFF
--- a/runner/jobserv_runner/handlers/simple.py
+++ b/runner/jobserv_runner/handlers/simple.py
@@ -224,6 +224,18 @@ class SimpleHandler(object):
         secrets = os.path.join(self.run_dir, 'secrets')
         if not os.path.exists(secrets):
             os.mkdir(secrets)  # probably a rebooted run
+
+        # Deal with docker rate-limiting:
+        try:
+            with open(os.path.expanduser('~/.docker/config.json')) as fin:
+                # copy this into container. It may have hub.docker.io read-only
+                # credentials required to avoid rate-limited pulls
+                secret = os.path.join(secrets, 'docker_host_config.json')
+                with open(secret, 'w') as fout:
+                    fout.write(fin.read())
+        except FileNotFoundError:
+            log.info('Default docker configuration detected')
+
         for secret, value in (self.rundef.get('secrets') or {}).items():
             log.info('Creating secret: %s', secret)
             with open(os.path.join(secrets, secret), 'w') as f:


### PR DESCRIPTION
Not great, but docker now rate-limits container pulling. This change
allows us to copy our host's config into the run's container. Then
a script like ci-scripts's apps/build.sh can use this for its docker
config.

Signed-off-by: Andy Doan <andy@foundries.io>