### PR TITLE
Fix URL for raw files in GitLab

### DIFF
--- a/jobserv/git_poller.py
+++ b/jobserv/git_poller.py
@@ -78,7 +78,10 @@ def _get_projdef(entry: PollerEntry) -> Optional[ProjectDefinition]:
 
     if gitlab:
         headers['PRIVATE-TOKEN'] = gitlab
-        url = repo.replace('.git', '') + '/raw/master/' + defile
+        p = urlparse(repo)
+        proj_enc = quote_plus(p.path[1:].replace('.git', ''))
+        url = p.scheme + '://' + p.netloc + '/api/v4/projects/' + proj_enc + \
+            '/repository/files/' + quote_plus(defile) + '/raw?ref=master'
     elif 'github' in repo:
         if token:
             headers['Authorization'] = 'token ' + token


### PR DESCRIPTION
RAW files are not programmatically accessible buy '/raw' endpoint anymore.
Behaviour discovered after upgrade from v11 to v13.

Fix is aimed to use repository API instead of /raw endpoint.

Signed-off-by: kostyapenkov <kostya.penkov@foundries.io>