### PR TITLE
api: Improve ability to cancel a run

### DIFF
--- a/jobserv/api/build.py
+++ b/jobserv/api/build.py
@@ -110,6 +110,16 @@ def build_get_latest(proj):
     return jsendify({'build': b.as_json(detailed=True)})
 
 
+@blueprint.route('/builds/<int:build_id>/cancel', methods=('POST',))
+def build_cancel(proj, build_id):
+    permissions.assert_can_build(proj)
+    p = get_or_404(Project.query.filter_by(name=proj))
+    b = get_or_404(Build.query.filter_by(project=p, build_id=build_id))
+    for r in b.runs:
+        r.cancel()
+    return jsendify({}), 202
+
+
 @blueprint.route('/builds/<int:build_id>/promote', methods=('POST',))
 def build_promote(proj, build_id):
     permissions.assert_can_promote(proj, build_id)

--- a/jobserv/api/run.py
+++ b/jobserv/api/run.py
@@ -255,8 +255,7 @@ def run_rerun(proj, build_id, run):
 def run_cancel(proj, build_id, run):
     r = _get_run(proj, build_id, run)
     permissions.assert_can_build(r.build.project.name)
-    r.set_status(BuildStatus.CANCELLING)
-    db.session.commit()
+    r.cancel()
     return jsendify({}), 202
 
 

--- a/unit-test.sh
+++ b/unit-test.sh
@@ -25,6 +25,6 @@ $VENV/bin/pip3 install -r requirements.txt
 $VENV/bin/pip3 install junitxml==0.7 python-subunit==1.3.0
 
 set -o pipefail
-PYTHONPATH=./ $VENV/bin/python3 -m subunit.run discover \
+PYTHONPATH=./ $VENV/bin/python3 -m subunit.run ${TEST-discover} \
 	| $VENV/bin/subunit2junitxml --no-passthrough \
 	| tee /archive/junit.xml


### PR DESCRIPTION
In the past we only cancelled Runs in RUNNING. This is really annoying
when you have a bunch of things QUEUED and want to clean them up.

Signed-off-by: Andy Doan <andy@foundries.io>