### PR TITLE
worker: use 'concurrent_runs' from config

### DIFF
--- a/jobserv_worker.py
+++ b/jobserv_worker.py
@@ -160,7 +160,7 @@ class HostProps(object):
     def available_runners():
         locks = None
         try:
-            locks = RunLocks(2)
+            locks = RunLocks(int(config['jobserv']['concurrent_runs']))
             yield locks
         finally:
             if locks:


### PR DESCRIPTION
Worker did ignore `concurrent_runs` from config.
Capacity of each worker always was 2 runs, despite other number
specified in config.

Signed-off-by: kostyapenkov <kostya.penkov@foundries.io>