### PR TITLE
fixup! models: Fix scheduler issue with synchronous projects

### DIFF
--- a/jobserv/models.py
+++ b/jobserv/models.py
@@ -504,10 +504,9 @@ class Run(db.Model, StatusMixin):
         sync_projects = {}
         okay_sync_builds = {}
         rows = cursor.fetchall()
-        oldest_build_id = 0
+        oldest_builds = {}
         for (run_id, build_id, status, proj_id, sync, tag) in rows:
-            if not oldest_build_id:
-                oldest_build_id = build_id
+            oldest_builds.setdefault(proj_id, build_id)
             if status == 2 and sync:
                 sync_projects[proj_id] = True
                 okay_sync_builds[build_id] = True
@@ -517,7 +516,7 @@ class Run(db.Model, StatusMixin):
                         # if its a sync build, we have to make sure this worker
                         # isn't finding work on a newer build that should be
                         # completed first
-                        if not sync or build_id == oldest_build_id:
+                        if not sync or build_id == oldest_builds[proj_id]:
                             break
                 else:
                     continue


### PR DESCRIPTION
We weren't taking into account that build ids come from multiple
projects