### PR TITLE
models: Account for UPLOADING runs in sync projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN mkdir -p $APPDIR
 
 COPY ./requirements.txt /srv/jobserv/
 
-RUN apk --no-cache add python3 py3-pip mysql-client python3-dev musl-dev g++ openssl libffi-dev openssl-dev rust cargo && \
+RUN apk --no-cache add python3 py3-pip mysql-client python3-dev musl-dev g++ openssl libffi-dev openssl-dev rust cargo linux-headers && \
 	pip3 install --upgrade pip setuptools && \
 	pip3 install -r $APPDIR/requirements.txt && \
-	apk del python3-dev musl-dev g++ libffi-dev openssl-dev rust cargo
+	apk del python3-dev musl-dev g++ libffi-dev openssl-dev rust cargo linux-headers
 
 COPY ./ $APPDIR/
 RUN cd $APPDIR/runner && python3 ./setup.py bdist_wheel

--- a/jobserv/api/run.py
+++ b/jobserv/api/run.py
@@ -384,7 +384,8 @@ def run_get_artifact(proj, build_id, run, path):
             end = fd.seek(0, 2)
             if offset >= end:
                 # TODO should be this:
-                # return b"", 200, {"Content-Type": "text/html", "X-RUN-STATUS": r.status.name}
+                # return b"", 200,
+                #  {"Content-Type": "text/html", "X-RUN-STATUS": r.status.name}
                 # but the original implementation was broke:
                 offset = 0
             fd.seek(offset, 0)

--- a/jobserv/models.py
+++ b/jobserv/models.py
@@ -523,7 +523,7 @@ class Run(db.Model, StatusMixin):
         conn = db.session.connection().connection
         cursor = conn.cursor()
 
-        # Find queued(status=1) and running(status=2) runs
+        # Find queued(status=1), running(status=2), and uploading(status=6) runs
         cursor.execute(
             """
             SELECT
@@ -533,7 +533,7 @@ class Run(db.Model, StatusMixin):
             JOIN builds on builds.id = runs.build_id
             JOIN projects on projects.id = builds.proj_id
             WHERE
-                runs._status in (1, 2)
+                runs._status in (1, 2, 6)
               ORDER BY
                 runs._status DESC, runs.queue_priority DESC,
                 runs.build_id ASC, runs.id ASC
@@ -551,7 +551,7 @@ class Run(db.Model, StatusMixin):
         oldest_builds = {}
         for (run_id, build_id, status, proj_id, sync, tag) in rows:
             oldest_builds.setdefault(proj_id, build_id)
-            if status == 2 and sync:
+            if status in (2, 6) and sync:
                 sync_projects[proj_id] = True
                 okay_sync_builds[build_id] = True
             elif status == 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ bcrypt==3.2.0
 cryptography==3.4.8
 dataclasses==0.6
 google-cloud-storage==1.42.0
+google-crc32c==1.1.2  # indirect, 1.1.3 won't build in alpine
 gunicorn==20.1.0
 pykwalify==1.8.0
 python-dateutil==2.8.2


### PR DESCRIPTION
We have a bug where a synchronous project can have CI runs
mis-scheduled. Here's the simplest flow:

* Two builds (one run each) builds for project get queued, 1 and 2.
* Build 1's run's goes into UPLOADING
* A worker check's in for work and gets assigned Build 2's run

The scheduler needs to filter on uploading as well as running.

Signed-off-by: Andy Doan <andy@foundries.io>