### PR TITLE
models: Increase column length for Build annotation

### DIFF
--- a/jobserv/models.py
+++ b/jobserv/models.py
@@ -20,6 +20,7 @@ import sqlalchemy.dialects.mysql.mysqldb as mysqldb
 from cryptography.fernet import Fernet
 from flask import url_for
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 
@@ -28,11 +29,15 @@ from jobserv.settings import (
     JOBS_DIR,
     RUN_URL_FMT,
     SECRETS_FERNET_KEY,
+    SQLALCHEMY_DATABASE_URI,
     WORKER_DIR,
 )
 from jobserv.stats import StatsClient
 
 db = SQLAlchemy()
+ANNOTATION_COLUMN_TYPE = MEDIUMTEXT
+if "mysql" not in SQLALCHEMY_DATABASE_URI:
+    ANNOTATION_COLUMN_TYPE = db.Text
 
 
 def hack_create_connect_args(*args, **kwargs):
@@ -267,7 +272,7 @@ class Build(db.Model, StatusMixin):
     trigger_name = db.Column(db.String(80))
 
     name = db.Column(db.String(256))
-    annotation = db.Column(db.Text())
+    annotation = db.Column(ANNOTATION_COLUMN_TYPE())
 
     project = db.relationship(Project)
     runs = db.relationship(

--- a/migrations/versions/8c2f916d3b24_.py
+++ b/migrations/versions/8c2f916d3b24_.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 8c2f916d3b24
+Revises: 3de1dc6abf74
+Create Date: 2021-09-07 16:51:57.866563
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '8c2f916d3b24'
+down_revision = '3de1dc6abf74'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('builds', 'annotation', existing_type=mysql.TEXT, type_=mysql.MEDIUMTEXT)
+
+
+def downgrade():
+    op.alter_column('builds', 'annotation', existing_type=mysql.MEDIUMTEXT, type_=mysql.TEXT)


### PR DESCRIPTION
We've hit a release notes for the LmP with 129K text. This change only
works for mysql, so was done in a way that won't break normal local
sqlite development flows.

Signed-off-by: Andy Doan <andy@foundries.io>