### PR TITLE
Add a re-run permission

### DIFF
--- a/jobserv/api/run.py
+++ b/jobserv/api/run.py
@@ -283,7 +283,7 @@ def run_update(proj, build_id, run):
 @blueprint.route("/<run>/rerun", methods=("POST",))
 def run_rerun(proj, build_id, run):
     r = _get_run(proj, build_id, run)
-    permissions.assert_internal_user()
+    permissions.assert_can_rerun(r)
     for t in r.tests:
         db.session.delete(t)
     r.set_status(BuildStatus.QUEUED)

--- a/jobserv/permissions.py
+++ b/jobserv/permissions.py
@@ -62,6 +62,11 @@ def assert_can_build(project):
     assert_internal_user()
 
 
+def assert_can_rerun(run):
+    """Is the requestor allowed to re-run this run"""
+    assert_internal_user()
+
+
 def assert_create_trigger(proj):
     """Is the requestor allowed to create triggers on a project."""
     return assert_internal_user()


### PR DESCRIPTION
In some cases you may want to have specific controls over who can
re-run a Run. This makes it easier to do without having to hack
the permissions api.

Signed-off-by: Andy Doan <andy@foundries.io>