### PR TITLE
runner: Make git operations retriable

### DIFF
--- a/runner/jobserv_runner/handlers/git_poller.py
+++ b/runner/jobserv_runner/handlers/git_poller.py
@@ -140,7 +140,7 @@ class GitPoller(SimpleHandler):
             log.info("Git install supports LFS")
             self._lfs_initialize(env)
 
-        if not log.exec(["git", "clone", clone_url, dst], env=env):
+        if not log.exec_retriable(["git", "clone", clone_url, dst], env=env):
             raise HandlerError("Unable to clone: " + clone_url)
 
         sha = self.rundef["env"].get("GIT_SHA")
@@ -154,7 +154,7 @@ class GitPoller(SimpleHandler):
                 if not log.exec(["git", "submodule", "init"], cwd=dst, env=env):
                     raise HandlerError("Unable to init submodule(s)")
 
-                if not log.exec(
+                if not log.exec_retriable(
                     ["git", "submodule", "update", "--init", "--recursive"],
                     cwd=dst,
                     env=env,

--- a/runner/jobserv_runner/handlers/simple.py
+++ b/runner/jobserv_runner/handlers/simple.py
@@ -104,6 +104,15 @@ class JobServLogger(ContextLogger):
                     self.error("unable to update run output: %s", e.output)
             return False
 
+    def exec_retriable(self, cmd_args, cwd=None, env=None, hung_cb=None):
+        for i in range(4):
+            if i:
+                self.error("command failed, retrying in %d seconds", i)
+                time.sleep(i)
+            if self.exec(cmd_args, cwd, env, hung_cb):
+                return True
+        return False
+
     def _write(self, msg):
         if not self.jobserv.SIMULATED:
             return super()._write(msg)


### PR DESCRIPTION
We get enough support issues with git-clone failing, that making this
retriable would help a bunch. 9 times out of 10 this solves the issue.

Signed-off-by: Andy Doan <andy@foundries.io>