### PR TITLE
worker: Improve logic for docker-clean

### DIFF
--- a/jobserv_worker.py
+++ b/jobserv_worker.py
@@ -566,7 +566,7 @@ def _docker_clean():
                 deletes.append(containers[i])
         if deletes:
             log.info("Cleaning up old containers:\n  %s", "\n  ".join(deletes))
-            subprocess.check_output(["docker", "rm", "-v"] + deletes)
+            subprocess.check_call(["docker", "rm", "-v"] + deletes)
     except subprocess.CalledProcessError as e:
         log.exception(e)
 

--- a/jobserv_worker.py
+++ b/jobserv_worker.py
@@ -567,6 +567,7 @@ def _docker_clean():
         if deletes:
             log.info("Cleaning up old containers:\n  %s", "\n  ".join(deletes))
             subprocess.check_call(["docker", "rm", "-v"] + deletes)
+        subprocess.check_call(["docker", "volume", "prune", "-f"])
     except subprocess.CalledProcessError as e:
         log.exception(e)
 

--- a/jobserv_worker.py
+++ b/jobserv_worker.py
@@ -614,7 +614,7 @@ def cmd_loop(args):
                 now = time.time()
                 if HostProps.idle():
                     log.debug("Worker is idle")
-                    if now - last_busy > idle_threshold:
+                    if args.idle_command and now - last_busy > idle_threshold:
                         log.info("Worker is idle, calling %s", args.idle_command)
                         subprocess.check_call([args.idle_command])
                 else:


### PR DESCRIPTION
We've recently seen a CI worker run out of disk space daily. It came down to two issues:

1) A recent change, 2fd3222b1b6afd58e700f33d61c18e4864727df1, accidentally started calling the idle handler even if it wasn't configured. This was leading to an exception. The docker-clean code path doesn't get called when this happens, so our clean up logic was getting skipped for idle workers. This lead to the increase disk space loss we were seeing

2) We need to clean unused volumes to re-claim disk space. This issue has always been present but has been happening more often recently - only partly do to #1.