### PR TITLE
api: Include host_tag for status API

### DIFF
--- a/jobserv/api/health.py
+++ b/jobserv/api/health.py
@@ -50,6 +50,7 @@ def run_health():
             "run": run.name,
             "url": url,
             "created": run.build.status_events[0].time,
+            "host_tag": run.host_tag,
         }
 
         if run.status == BuildStatus.QUEUED:


### PR DESCRIPTION
The host tag is important for understanding why things are queued up.

Signed-off-by: Andy Doan <andy@foundries.io>