### PR TITLE
worker: Allow workers to limit container memory usage

### DIFF
--- a/runner/jobserv_runner/handlers/simple.py
+++ b/runner/jobserv_runner/handlers/simple.py
@@ -237,6 +237,10 @@ class SimpleHandler(object):
             if self.rundef.get("privileged"):
                 log.info('Running with "--privileged"')
                 cmd.append("--privileged")
+            if self.rundef.get("max-mem-bytes"):
+                maxbytes = self.rundef.get("max-mem-bytes")
+                log.info("Running with --memory=%d", maxbytes)
+                cmd.extend(["--memory", str(maxbytes)])
             if self.rundef.get("container-user"):
                 user = self.rundef.get("container-user")
                 log.info("Overriding container user to be: %s", user)


### PR DESCRIPTION
CI jobs may launch containers that can eat up so much memory that the OOM process starts to kill the wrong stuff. This helps a worker protect itself and have a CI job fail more gracefully. eg "exit 137" means the process ran out of memory.

Signed-off-by: Andy Doan <andy@foundries.io>