### PR TITLE
storage: Handle rundef as a dictionary

### DIFF
--- a/jobserv/api/run.py
+++ b/jobserv/api/run.py
@@ -138,7 +138,7 @@ def _handle_triggers(storage, run):
     projdef = ProjectDefinition(
         yaml.safe_load(storage.get_project_definition(run.build))
     )
-    rundef = json.loads(storage.get_run_definition(run))
+    rundef = storage.get_run_definition(run)
     secrets = rundef.get("secrets")
     params = rundef.get("env", {})
     params["H_TRIGGER_URL"] = request.url
@@ -178,7 +178,7 @@ def _handle_triggers(storage, run):
 
 def _failed_tests(storage, run):
     failures = False
-    rundef = json.loads(storage.get_run_definition(run))
+    rundef = storage.get_run_definition(run)
     grepping = rundef.get("test-grepping")
     if grepping:
         test_pat = grepping.get("test-pattern")
@@ -305,7 +305,6 @@ def _get_run_def(proj, build_id, run):
     try:
         _authenticate_runner(r)
     except ApiError:
-        rundef = json.loads(rundef)
         if not permissions.run_can_access_secrets(r):
             # The requestor is not authorized to view secrets
             secrets = rundef.get("secrets")
@@ -324,7 +323,7 @@ def run_get_definition(proj, build_id, run):
 @blueprint.route("/<run>/progress-regex", methods=("GET",))
 def run_get_progress_regex(proj, build_id, run):
     r = _get_run(proj, build_id, run)
-    rundef = json.loads(Storage().get_run_definition(r))
+    rundef = Storage().get_run_definition(r)
     progress = rundef.get("console-progress")
     if progress:
         return jsendify(progress)

--- a/jobserv/api/worker.py
+++ b/jobserv/api/worker.py
@@ -80,7 +80,6 @@ def worker_list():
 
 
 def _fix_run_urls(rundef):
-    rundef = json.loads(rundef)
     parts = urllib.parse.urlparse(request.url)
     public = "%s://%s" % (parts.scheme, parts.hostname)
     if parts.port:
@@ -91,7 +90,6 @@ def _fix_run_urls(rundef):
     url = rundef["env"].get("H_TRIGGER_URL")
     if url:
         rundef["env"]["H_TRIGGER_URL"] = public + urllib.parse.urlparse(url).path
-    return json.dumps(rundef)
 
 
 @blueprint.route("workers/<name>/", methods=("GET",))
@@ -112,7 +110,9 @@ def worker_get(name):
                 s = Storage()
                 with s.console_logfd(r, "a") as f:
                     f.write("# Run sent to worker: %s\n" % name)
-                data["run-defs"] = [_fix_run_urls(s.get_run_definition(r))]
+                rundef = s.get_run_definition(r)
+                _fix_run_urls(rundef)
+                data["run-defs"] = [json.dumps(rundef)]
                 r.build.refresh_status()
             except Exception:
                 r.worker = None

--- a/jobserv/project.py
+++ b/jobserv/project.py
@@ -4,7 +4,6 @@
 import copy
 import os
 import itertools
-import json
 
 from flask import url_for
 
@@ -171,7 +170,7 @@ class ProjectDefinition(object):
         rundef["env"]["H_BUILD"] = str(dbrun.build.build_id)
         rundef["env"]["H_RUN"] = dbrun.name
         dbrun.host_tag = rundef["host-tag"]
-        return json.dumps(rundef, indent=2)
+        return rundef
 
     @classmethod
     def _check_trigger_depth(clazz, proj_data, parent, trigger, depth):

--- a/jobserv/storage/base.py
+++ b/jobserv/storage/base.py
@@ -71,10 +71,11 @@ class BaseStorage(object):
 
     def set_run_definition(self, run, definition):
         path = self._get_run_path(run, ".rundef.json")
-        self._create_from_string(path, definition)
+        self._create_from_string(path, json.dumps(definition))
 
     def get_run_definition(self, run):
-        return self._get_as_string(self._get_run_path(run, ".rundef.json"))
+        def_str = self._get_as_string(self._get_run_path(run, ".rundef.json"))
+        return json.loads(def_str)
 
     def console_logfd(self, run, mode="r"):
         path = os.path.join(JOBS_DIR, self._get_run_path(run, "console.log"))

--- a/jobserv/trigger.py
+++ b/jobserv/trigger.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2017 Linaro Limited
 # Author: Andy Doan <andy.doan@linaro.org>
 
-import json
 import logging
 import traceback
 
@@ -26,17 +25,12 @@ def _check_for_trigger_upgrade(rundef, trigger_type, parent_trigger_type):
     """
     if parent_trigger_type == "github_pr":
         if trigger_type == "simple":
-            rundef = json.loads(rundef)
             rundef["trigger_type"] = "github_pr"
             logging.info("Updating the rundef from simple->github_pr")
-            rundef = json.dumps(rundef, indent=2)
     elif parent_trigger_type == "git_poller":
         if trigger_type == "simple":
-            rundef = json.loads(rundef)
             rundef["trigger_type"] = "git_poller"
             logging.info("Updating the rundef from simple->gith_poller")
-            rundef = json.dumps(rundef, indent=2)
-    return rundef
 
 
 def trigger_runs(
@@ -60,7 +54,7 @@ def trigger_runs(
             db.session.flush()
             added.append(r)
             rundef = projdef.get_run_definition(r, run, trigger, params, secrets)
-            rundef = _check_for_trigger_upgrade(rundef, trigger["type"], parent_type)
+            _check_for_trigger_upgrade(rundef, trigger["type"], parent_type)
             storage.set_run_definition(r, rundef)
     except ApiError:
         logging.exception("ApiError while triggering runs for: %r", trigger)

--- a/tests/test_api_test.py
+++ b/tests/test_api_test.py
@@ -104,7 +104,7 @@ class TestAPITest(JobServTest):
 
         self.test.run.tests[0].status = BuildStatus.PASSED
         db.session.commit()
-        storage().get_run_definition.return_value = "{}"
+        storage().get_run_definition.return_value = {}
         headers.append(("X-RUN-STATUS", "FAILED"))
         self._post("/projects/proj-1/builds/1/runs/run0/", None, headers=headers)
         db.session.refresh(self.test.run)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2017 Linaro Limited
 # Author: Andy Doan <andy.doan@linaro.org>
 
-import json
 import os
 
 import yaml
@@ -182,7 +181,7 @@ class ProjectSchemaTest(JobServTest):
             trigger = proj._data["triggers"][0]
             run = trigger["runs"][0]
             rundef = proj.get_run_definition(dbrun, run, trigger, {}, {})
-            repo = json.loads(rundef).get("script-repo")
+            repo = rundef.get("script-repo")
             self.assertEqual({"clone-url": "url", "path": "path/foo.sh"}, repo)
 
     @patch("jobserv.project.url_for")
@@ -239,8 +238,7 @@ class ProjectSchemaTest(JobServTest):
             trigger = proj._data["triggers"][0]
             run = trigger["runs"][0]
             rundef = proj.get_run_definition(dbrun, run, trigger, {}, {})
-            data = json.loads(rundef)
-            self.assertEqual("aarch6*", data["host-tag"])
+            self.assertEqual("aarch6*", rundef["host-tag"])
             self.assertEqual("aarch6*", dbrun.host_tag)
 
     def test_host_tag_rundef_loopon(self):
@@ -256,15 +254,13 @@ class ProjectSchemaTest(JobServTest):
             trigger = proj._data["triggers"][0]
             run = trigger["runs"][1]
             rundef = proj.get_run_definition(dbrun, run, trigger, {}, {})
-            data = json.loads(rundef)
-            self.assertEqual("aarch64", data["host-tag"])
+            self.assertEqual("aarch64", rundef["host-tag"])
             self.assertEqual("aarch64", dbrun.host_tag)
 
             trigger = proj._data["triggers"][0]
             run = trigger["runs"][2]
             rundef = proj.get_run_definition(dbrun, run, trigger, {}, {})
-            data = json.loads(rundef)
-            self.assertEqual("armhf", data["host-tag"])
+            self.assertEqual("armhf", rundef["host-tag"])
             self.assertEqual("armhf", dbrun.host_tag)
 
     def test_host_tag_rundef_loopon_bad(self):
@@ -289,7 +285,6 @@ class ProjectSchemaTest(JobServTest):
             trigger = proj._data["triggers"][0]
             run = trigger["runs"][0]
             rundef = proj.get_run_definition(dbrun, run, trigger, {}, {})
-            data = json.loads(rundef)
-            self.assertEqual("GLOBAL", data["env"]["GLOBAL_PARAM"])
-            self.assertEqual("RUN", data["env"]["RUN_PARAM"])
-            self.assertEqual("TRIGGER", data["env"]["TRIGGER_PARAM"])
+            self.assertEqual("GLOBAL", rundef["env"]["GLOBAL_PARAM"])
+            self.assertEqual("RUN", rundef["env"]["RUN_PARAM"])
+            self.assertEqual("TRIGGER", rundef["env"]["TRIGGER_PARAM"])


### PR DESCRIPTION
Having to consider the run definition to be a string is quite tedious for callers.

Signed-off-by: Andy Doan <andy@foundries.io>