### PR TITLE
runner: Log info about failed tests

### DIFF
--- a/runner/jobserv_runner/handlers/simple.py
+++ b/runner/jobserv_runner/handlers/simple.py
@@ -500,6 +500,8 @@ class SimpleHandler(object):
                     r.status_code,
                     r.text,
                 )
+        if failed:
+            log.error("Found failure(s)")
         return failed
 
     def test_suite_errors(self):


### PR DESCRIPTION
We don't make the test logs very clear about what junit test failed. We do show the test results, but it's not super clear reading the console log. This will help people more easily see they need to go dig into test results.

Signed-off-by: Andy Doan <andy@foundries.io>