### PR TITLE
worker: Remove offline worker ping logs

### DIFF
--- a/jobserv/worker.py
+++ b/jobserv/worker.py
@@ -42,6 +42,8 @@ def _check_worker(w):
             w.online = False
             with StatsClient() as c:
                 c.worker_offline(w)
+            os.unlink(pings_log)
+            return
 
         # based on rough calculations a 1M file is about 9000 entries which is
         # about 2 days worth of information

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -46,6 +46,7 @@ class TestWorkerMonitor(JobServTest):
         _check_workers()
         db.session.refresh(self.worker)
         self.assertFalse(self.worker.online)
+        self.assertRaises(FileNotFoundError, os.stat, self.worker.pings_log)
 
     @patch("jobserv.worker.WORKER_ROTATE_PINGS_LOG")
     def test_rotate(self, rotate):


### PR DESCRIPTION
We tend to exhaust of shared volume every few months because the number of offline worker ping logs grows. We almost don't even need  the pings log. All the info is getting sent to StatsD. However, its easier to "fix" this by deleting them as they go offline.