### PR TITLE
worker: Don't check for surges if there's no WORKER_DIR

### DIFF
--- a/jobserv/worker.py
+++ b/jobserv/worker.py
@@ -223,8 +223,11 @@ def run_monitor_workers():
     log.info("worker monitor has started")
     try:
         while True:
-            log.debug("checking workers")
-            _check_workers()
+            if os.path.isdir(WORKER_DIR):
+                log.debug("checking workers")
+                _check_workers()
+            else:
+                log.info("Skipping check for surges. WORKER_DIR does not exist")
             log.debug("checking queue")
             _check_queue()
             log.debug("checking stuck jobs")


### PR DESCRIPTION
This can happen on fresh installs where the system has never had a worker check in. If we have no workers - there's no point trying to see if we need surges enabled.