### PR TITLE
requirements: bump werkzeug for CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ PyJWT==2.8.0
 PyMySQL==1.1.0
 PyYAML==6.0.1
 SQLAlchemy==1.4.23
-Werkzeug==2.3.7
+Werkzeug==3.0.1
 bcrypt==4.0.1
 cryptography==41.0.4
 dataclasses==0.6


### PR DESCRIPTION
All version <3.0.1 have a CVE:

 https://nvd.nist.gov/vuln/detail/CVE-2023-46136

The release notes for 3.0 are relatively small:

 * Remove previously deprecated code. #2768

 * Deprecate the __version__ attribute. Use feature detection, or importlib.metadata.version("werkzeug"), instead. #2770

 * generate_password_hash uses scrypt by default. #2769

 * Add the "werkzeug.profiler" item to the WSGI environ dictionary passed to ProfilerMiddleware’s filename_format function. It contains the elapsed and time values for the profiled request. #2775

 * Explicitly marked the PathConverter as non path isolating. #2784

Jobserv does the PathConverter. However, we've tested this patch in gavelci.us w/o any issues.