### PR TITLE
Began to build image with the plugin mariadb-connector-c to fix issue to connect in the database from jobserv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p $APPDIR
 
 COPY ./requirements.txt /srv/jobserv/
 
-RUN apk --no-cache add python3 py3-pip mysql-client python3-dev musl-dev g++ openssl libffi-dev openssl-dev linux-headers && \
+RUN apk --no-cache add python3 py3-pip mysql-client python3-dev musl-dev g++ openssl libffi-dev openssl-dev linux-headers mariadb-connector-c && \
 	pip3 install --break-system-packages -r $APPDIR/requirements.txt && \
 	apk del python3-dev musl-dev g++ libffi-dev openssl-dev linux-headers
 


### PR DESCRIPTION
Following the issue faced:

```
$ kubectl logs jobserv-backup-manual-20240228184829-vrpzj -n ci mysqldump: Got error: 1045: "Plugin caching_sha2_password could not be loaded: Error loading shared library /usr/lib/mariadb/plugin/caching_sha2_password.so: No such file or directory" when trying to connect
{"written_at": "2024-02-28T18:48:41.294Z", "written_ts": 1709146121294839000, "msg": "Unable to send email:_|  Content-Type: text/plain; charset=\"us-ascii\"_|  MIME-Version: 1.0_|  Content-Transfer-Encoding: 7bit_|  To: _|  From: bot@foundries.io_|  Subject: jobserv: DB Backup Failed_|  _|  Traceback (most recent call last):_|    File \"/srv/jobserv/jobserv/notify.py\", line 238, in wrapper_|      func(*args, **kwargs)_|    File \"/srv/jobserv/jobserv/app.py\", line 300, in backup_|      subprocess.check_call(command, stdout=f)_|    File \"/usr/lib/python3.11/subprocess.py\", line 413, in check_call_|      raise CalledProcessError(retcode, cmd)_|  subprocess.CalledProcessError: Command '('mysqldump', '--user=jobserv', '--password=ba9bcf18804fb56d0aeb337a727c62a2f1a5d5cf', '--host=percona-galera-pxc.data', '--single-transaction', '--no-tablespaces', 'jobserv')' returned non-zero exit status 2._SMTPRecipientsRefused({})", "type": "log", "logger": "jobserv.flask", "thread": "MainThread", "level": "ERROR", "module": "notify", "line_no": 124, "correlation_id": "fdcb8e4f-d669-11ee-a88c-da7285c78278"}
Traceback (most recent call last):
  File "/usr/bin/flask", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.11/site-packages/flask/cli.py", line 1064, in main
    cli.main()
  File "/usr/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/flask/cli.py", line 358, in decorator
    return __ctx.invoke(f, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/jobserv/jobserv/notify.py", line 238, in wrapper
    func(*args, **kwargs)
  File "/srv/jobserv/jobserv/app.py", line 300, in backup
    subprocess.check_call(command, stdout=f)
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('mysqldump', '--user=jobserv', '--password=xxxxxxxxxxxxxxxxxxxxxxx', '--host=percona-galera-pxc.data', '--single-transaction', '--no-tablespaces', 'jobserv')' returned non-zero exit status 2.
```

**Test performed with MEDs**

After build an image with the change and call the cronjob manually it worked as expected

```
jobserv-backup-manual-20240229103208-mf75g   0/1     Completed                0               42s
jobserv-backup-manual-20240229103243-nrzsg   0/1     Completed                0               7s
```

Closes: https://foundriesio.atlassian.net/browse/FFTK-3060
Signed-off-by: Camila Macedo <camila.macedo@foundries.io>