### PR TITLE
api: Fix long standing error handling issue

### DIFF
--- a/jobserv/api/__init__.py
+++ b/jobserv/api/__init__.py
@@ -3,6 +3,7 @@
 import traceback
 
 from sqlalchemy.exc import DataError
+from werkzeug.exceptions import HTTPException
 
 from flask import current_app
 
@@ -34,6 +35,10 @@ def register_blueprints(app):
     @app.errorhandler(ApiError)
     def api_error(e):
         return e.resp
+
+    @app.errorhandler(HTTPException)
+    def werkzeug_err(e):
+        return e.response
 
     @app.errorhandler(DataError)
     def data_error(e):


### PR DESCRIPTION
We've had a long standing bug where code in modules will do something like raise an HTTPException. Rather than return that, our default 500 exception handler gets hit and we wrap something like a 401 error with a 500 error.