### PR TITLE
Add mechanism for workers to upload log data

### DIFF
--- a/dev-shell
+++ b/dev-shell
@@ -8,7 +8,7 @@ if [ -n "$INDOCKER" ] ; then
 	git config --system user.email "bot@foundries.io"
 	git config --system protocol.file.allow always
 
-	pip3 install black
+	pip3 install black --break-system-packages
 	exec /bin/bash
 fi
 

--- a/jobserv/api/worker.py
+++ b/jobserv/api/worker.py
@@ -220,6 +220,19 @@ def worker_event(name):
     return jsendify({}, 201)
 
 
+@blueprint.route("workers/<name>/logs/", methods=["PUT"])
+@worker_authenticated
+def worker_logs(name):
+    if not request.worker.enlisted:
+        return jsendify({}, 403)
+    if request.headers["content-encoding"] != "gzip":
+        raise ApiError(400, "gzip content-encoding required")
+    payload = request.get_data()
+    if payload:
+        request.worker.store_logs(payload)
+    return jsendify({}, 202)
+
+
 @blueprint.route("workers/<name>/volumes-deleted/", methods=["GET"])
 @worker_authenticated
 def worker_deleted_volumes(name):

--- a/jobserv/models.py
+++ b/jobserv/models.py
@@ -884,6 +884,19 @@ class Worker(db.Model):
         with open(logfile, "a") as f:
             f.write(json.dumps(payload))
 
+    def store_logs(self, logs_gz: bytes):
+        """Store a gzip copy of log data from a worker. Keeps this seperate
+        from the pings log because we want to keep this around *after*
+        a worker has been deleted so we can debug.
+
+        The worker-monitor logic can delete files old files for us.
+        """
+        logs = os.path.join(WORKER_DIR, "logs", self.name + ".gz")
+        if not os.path.exists(logs):
+            os.makedirs(os.path.dirname(logs))
+        with open(logs, "wb") as f:
+            f.write(logs_gz)
+
     @property
     def pings_log(self):
         return os.path.join(WORKER_DIR, self.name, "pings.log")

--- a/jobserv/settings.py
+++ b/jobserv/settings.py
@@ -86,6 +86,9 @@ if CARBON_PREFIX and CARBON_PREFIX[-1] != ".":
 # record of all worker pings.
 WORKER_ROTATE_PINGS_LOG = os.environ.get("ROTATE_PINGS_LOG", "0") != "0"
 
+# How many days to keep worker log files around before deleting
+WORKER_LOGS_THRESHOLD_DAYS = int(os.environ.get("WORKER_LOGS_THRESHOLD_DAYS", "4"))
+
 RUNNER = os.path.join(
     os.path.dirname(__file__), "../runner/dist/jobserv_runner-0.1-py3-none-any.whl"
 )


### PR DESCRIPTION
This can be a handy feature in certain cases. Especially for people with ephemeral workers that need to share some debug data.