### PR TITLE
storage: Lazy load gcs bucket

### DIFF
--- a/jobserv/storage/gce_storage.py
+++ b/jobserv/storage/gce_storage.py
@@ -42,10 +42,17 @@ class Storage(BaseStorage):
         super().__init__()
         creds_file = os.environ.get("GCE_CREDS")
         if creds_file:
-            client = storage.Client.from_service_account_json(creds_file)
+            self.client = storage.Client.from_service_account_json(creds_file)
         else:
-            client = storage.Client()
-        self.bucket = client.get_bucket(GCE_BUCKET)
+            self.client = storage.Client()
+        self._bucket = None
+
+    @property
+    def bucket(self):
+        if self._bucket:
+            return self._bucket
+        self._bucket = self.client.get_bucket(GCE_BUCKET)
+        return self._bucket
 
     @retry()
     def _create_from_string(self, storage_path, contents):


### PR DESCRIPTION
GCP suffered a massive outage today. The thing that affected us most was that calls to `get_bucket` were timing out. Many parts of code need a reference to the Storage object, but they don't need the bucket. For example, a CI run will mostly be streaming console logs to disk.

By lazy loading the bucket reference, we only pay the price of a GCS failure in code paths that require it.