### PR TITLE
Chore/update python runtime

### DIFF
--- a/.jobserv.yml
+++ b/.jobserv.yml
@@ -19,7 +19,7 @@ triggers:
     type: git_poller
     params:
       GIT_URL: "https://github.com/foundriesio/jobserv.git"
-      GIT_POLL_REFS: "refs/heads/master"
+      GIT_POLL_REFS: "refs/heads/chore/update_python_runtime"
     runs:
       - name: build-container
         container: docker:dind
@@ -33,7 +33,7 @@ triggers:
     type: git_poller
     params:
       GIT_URL: "https://github.com/foundriesio/jobserv.git"
-      GIT_POLL_REFS: "refs/heads/master"
+      GIT_POLL_REFS: "refs/heads/chore/update_python_runtime"
     runs:
       - name: flake8
         container: python:3.5-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM python:3.14.3-alpine3.23
 
 ENV APPDIR=/srv/jobserv
 ENV PYTHONPATH=$APPDIR
@@ -9,9 +9,9 @@ RUN mkdir -p $APPDIR
 
 COPY ./requirements.txt /srv/jobserv/
 
-RUN apk --no-cache add python3 py3-pip mysql-client python3-dev musl-dev g++ openssl libffi-dev openssl-dev linux-headers mariadb-connector-c && \
+RUN apk --no-cache add mysql-client musl-dev g++ openssl libffi-dev openssl-dev linux-headers mariadb-connector-c && \
 	pip3 install --break-system-packages -r $APPDIR/requirements.txt && \
-	apk del python3-dev musl-dev g++ libffi-dev openssl-dev linux-headers
+	apk del musl-dev g++ libffi-dev openssl-dev linux-headers
 
 COPY ./ $APPDIR/
 RUN cd $APPDIR/runner && python3 ./setup.py bdist_wheel

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -31,7 +31,7 @@ if [ -z "$FLASK_DEBUG" ] ; then
 	if [ -n "$STATSD_HOST" ] ; then
 		STATSD="--statsd-host $STATSD_HOST"
 	fi
-	exec /usr/bin/gunicorn $STATSD -w4 -b 0.0.0.0:8000 $FLASK_APP
+	exec /usr/local/bin/gunicorn $STATSD -w4 -b 0.0.0.0:8000 $FLASK_APP
 fi
 
-exec /usr/bin/flask run -h 0.0.0.0 -p 8000
+exec /usr/local/bin/flask run -h 0.0.0.0 -p 8000

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -4,7 +4,7 @@ create_flock_script () {
 	# /usr/bin/flock uses the "flock" call instead of fcntl.
 	# fcntl is required for NFS shares
 	cat > /tmp/flock <<EOF
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import fcntl
 import subprocess
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ PyYAML==6.0.1
 SQLAlchemy==1.4.54
 Werkzeug==3.1.6
 bcrypt==5.0.0
-cryptography==46.0.5
+cryptography==46.0.7
 dataclasses==0.6
 google-cloud-storage==2.10.0
 # gunicorn 20.1.0 switched from os.sendfile to socket.sendfile which causes
@@ -20,3 +20,4 @@ python-dateutil==2.8.2
 pytz==2023.3
 requests==2.32.5
 wheel==0.46.2
+setuptools==82.0.1


### PR DESCRIPTION
Update to Python3.14 runtime, also included cryptography 46.0.6. 